### PR TITLE
FA-05 - Implementação da funcionalidade de remoção de despesas

### DIFF
--- a/apps/api/src/modules/Expense/domain/repositories/IExpensesInMonthRepository.ts
+++ b/apps/api/src/modules/Expense/domain/repositories/IExpensesInMonthRepository.ts
@@ -7,7 +7,9 @@ export type UpdateExpenseMonthInput = {
   id: string;
   data: Partial<ExpenseMonth>;
 }
-export type RemoveExpenseMonthInput = { id: string, user_id: string };
+export type RemoveExpenseMonthInput = { id: string };
+export type FetchByExpenseIdInput = { expense_id?: string };
+export type FetchByExpenseIdOutput = [ExpenseMonthMapper[] | undefined, number];
 
 export interface IExpensesMonthRepository {
   create(args: ExpenseMonth[]): Promise<ExpenseMonthMapper[]>;
@@ -17,6 +19,7 @@ export interface IExpensesMonthRepository {
     user_id?: string,
   ): Promise<ExpenseMonthMapper[] | undefined>;
   findById(args: FindByIdInput): Promise<FindByIdOutput>;
+  fetchByExpenseId(args: FetchByExpenseIdInput): Promise<FetchByExpenseIdOutput>
   update(args: UpdateExpenseMonthInput): Promise<void>;
   remove(args: RemoveExpenseMonthInput): Promise<boolean>;
 }

--- a/apps/api/src/modules/Expense/domain/repositories/IExpensesInMonthRepository.ts
+++ b/apps/api/src/modules/Expense/domain/repositories/IExpensesInMonthRepository.ts
@@ -3,11 +3,11 @@ import { ExpenseMonth } from '../models/ExpenseMonth';
 
 export type FindByIdInput = { id: string, user_id: string };
 export type FindByIdOutput = ExpenseMonthMapper | undefined;
-
 export type UpdateExpenseMonthInput = {
   id: string;
   data: Partial<ExpenseMonth>;
 }
+export type RemoveExpenseMonthInput = { id: string, user_id: string };
 
 export interface IExpensesMonthRepository {
   create(args: ExpenseMonth[]): Promise<ExpenseMonthMapper[]>;
@@ -18,4 +18,5 @@ export interface IExpensesMonthRepository {
   ): Promise<ExpenseMonthMapper[] | undefined>;
   findById(args: FindByIdInput): Promise<FindByIdOutput>;
   update(args: UpdateExpenseMonthInput): Promise<void>;
+  remove(args: RemoveExpenseMonthInput): Promise<boolean>;
 }

--- a/apps/api/src/modules/Expense/domain/repositories/IExpensesRepository.ts
+++ b/apps/api/src/modules/Expense/domain/repositories/IExpensesRepository.ts
@@ -1,16 +1,14 @@
 import { ExpenseMapper } from '../../infra/typeorm/entities/ExpenseMapper';
 import { Expense } from '../models/Expense';
 
-export type UpdateExpenseInput = {
-  id: string;
-  data: Partial<Expense>;
-}
+export type UpdateExpenseInput = { id: string; data: Partial<Expense> };
+export type RemoveExpenseInput = { id: string, user_id: string };
 
 export interface IExpensesRepository {
   create(args: Expense): Promise<ExpenseMapper>;
   fetch(userId: string): Promise<ExpenseMapper[] | null>;
   fetchRecurringExpenses(): Promise<ExpenseMapper[] | undefined>;
   findById(id: string, userId: string): Promise<ExpenseMapper | null>;
-  remove(id: string): Promise<boolean>;
+  remove(args: RemoveExpenseInput): Promise<boolean>;
   update(args: UpdateExpenseInput): Promise<void>;
 }

--- a/apps/api/src/modules/Expense/domain/repositories/IExpensesRepository.ts
+++ b/apps/api/src/modules/Expense/domain/repositories/IExpensesRepository.ts
@@ -2,13 +2,15 @@ import { ExpenseMapper } from '../../infra/typeorm/entities/ExpenseMapper';
 import { Expense } from '../models/Expense';
 
 export type UpdateExpenseInput = { id: string; data: Partial<Expense> };
-export type RemoveExpenseInput = { id: string, user_id: string };
+export type RemoveExpenseInput = { id: string };
+
+export type FindByIdInput = { id: string, user_id: string };
 
 export interface IExpensesRepository {
   create(args: Expense): Promise<ExpenseMapper>;
   fetch(userId: string): Promise<ExpenseMapper[] | null>;
   fetchRecurringExpenses(): Promise<ExpenseMapper[] | undefined>;
-  findById(id: string, userId: string): Promise<ExpenseMapper | null>;
+  findById(args: FindByIdInput): Promise<ExpenseMapper | null>;
   remove(args: RemoveExpenseInput): Promise<boolean>;
   update(args: UpdateExpenseInput): Promise<void>;
 }

--- a/apps/api/src/modules/Expense/domain/services/CreateExpenseService.ts
+++ b/apps/api/src/modules/Expense/domain/services/CreateExpenseService.ts
@@ -55,7 +55,7 @@ export class CreateExpenseService {
         }),
       );
     } catch (err) {
-      await this.expensesRepository.remove(newExpense.id);
+      await this.expensesRepository.remove({ id: newExpense.id, user_id: expenseDTO.user_id });
       throw new AppError(err);
     }
 

--- a/apps/api/src/modules/Expense/domain/services/CreateExpenseService.ts
+++ b/apps/api/src/modules/Expense/domain/services/CreateExpenseService.ts
@@ -55,7 +55,7 @@ export class CreateExpenseService {
         }),
       );
     } catch (err) {
-      await this.expensesRepository.remove({ id: newExpense.id, user_id: expenseDTO.user_id });
+      await this.expensesRepository.remove({ id: newExpense.id });
       throw new AppError(err);
     }
 

--- a/apps/api/src/modules/Expense/domain/services/RemoveExpenseService.ts
+++ b/apps/api/src/modules/Expense/domain/services/RemoveExpenseService.ts
@@ -1,5 +1,6 @@
 import { inject, injectable } from 'tsyringe';
 
+import AppError from '@shared/errors/AppError';
 import { IExpensesRepository } from '../repositories/IExpensesRepository';
 import { IExpensesMonthRepository } from '../repositories/IExpensesInMonthRepository';
 
@@ -18,10 +19,32 @@ export class RemoveExpenseService {
   ) {}
 
   public async execute({ expense_id, user_id, is_only_one }: IRemoveExpenseDTO): Promise<boolean> {
-    if (is_only_one) {
-      return await this.expensesMonthRepository.remove({ id: expense_id, user_id });
+    if (!!is_only_one) {
+      const expenseMonthFound = await this.expensesMonthRepository.findById({ id: expense_id, user_id });
+      if (!expenseMonthFound) { throw new AppError('Expense parcel not exist'); }
+
+      const isParcelTheLastOne = await this.checkIfExpenseMonthIsOnlyOne(expenseMonthFound.expense_id)
+      if (!isParcelTheLastOne) {
+        return await this.expensesMonthRepository.remove({ id: expense_id });
+      }
+
+      await this.expensesMonthRepository.remove({ id: expense_id });
+      return await this.deleteFatherExpense(expenseMonthFound.expense_id, user_id);
     }
 
-    return this.expensesRepository.remove({ id: expense_id, user_id });
+    return await this.deleteFatherExpense(expense_id, user_id);
+  }
+
+  private async checkIfExpenseMonthIsOnlyOne(expense_id: string) {
+    const [, expenseMonthExistsCount] = await this.expensesMonthRepository.fetchByExpenseId({ expense_id });
+    return expenseMonthExistsCount === 1;
+  }
+
+  private async deleteFatherExpense(expense_id: string, user_id: string){
+    const expenseFound = await this.expensesRepository.findById({ id: expense_id, user_id });
+    if (!expenseFound) {
+      throw new AppError('Expense not exist');
+    }
+    return this.expensesRepository.remove({ id: expense_id });
   }
 }

--- a/apps/api/src/modules/Expense/domain/services/RemoveExpenseService.ts
+++ b/apps/api/src/modules/Expense/domain/services/RemoveExpenseService.ts
@@ -1,30 +1,27 @@
 import { inject, injectable } from 'tsyringe';
 
 import { IExpensesRepository } from '../repositories/IExpensesRepository';
+import { IExpensesMonthRepository } from '../repositories/IExpensesInMonthRepository';
 
 interface IRemoveExpenseDTO {
   expense_id: string;
+  /** Indica se o será removido apenas uma parcela da despesa ou todas as parcelas. */
+  is_only_one: boolean;
   user_id: string;
 }
 
 @injectable()
 export class RemoveExpenseService {
-  private expensesRepository: IExpensesRepository;
-
   constructor(
-    @inject('ExpensesRepository')
-    expensesRepository: IExpensesRepository,
-  ) {
-    this.expensesRepository = expensesRepository;
-  }
+    @inject('ExpensesRepository') private expensesRepository: IExpensesRepository,
+    @inject('ExpensesMonthRepository') private expensesMonthRepository: IExpensesMonthRepository
+  ) {}
 
-  public async execute({ expense_id, user_id }: IRemoveExpenseDTO): Promise<boolean> {
-    const expenseFound = await this.expensesRepository.findById(expense_id, user_id);
-
-    if (!expenseFound) {
-      return false;
+  public async execute({ expense_id, user_id, is_only_one }: IRemoveExpenseDTO): Promise<boolean> {
+    if (is_only_one) {
+      return await this.expensesMonthRepository.remove({ id: expense_id, user_id });
     }
 
-    return this.expensesRepository.remove(expense_id);
+    return this.expensesRepository.remove({ id: expense_id, user_id });
   }
 }

--- a/apps/api/src/modules/Expense/domain/services/__tests__/CreateExpenseService.spec.ts
+++ b/apps/api/src/modules/Expense/domain/services/__tests__/CreateExpenseService.spec.ts
@@ -67,16 +67,18 @@ describe('CreateExpenseService use case - Unit test', () => {
 
   it('should be able to remove expense if expenses month create is failed', async () => {
     jest.spyOn(CreateExpenseMonthService.prototype, 'execute').mockRejectedValueOnce('fake-error');
+
+    const userIdMock = v4()
     await expect(
       createExpenseService.execute({
         name: 'fake-expense-name',
         amount: 1200,
         parcel: 1,
-        user_id: v4(),
+        user_id: userIdMock,
         card_id: v4(),
         purchase_date: '2024-09-17',
       }),
     ).rejects.toBeInstanceOf(AppError);
-    expect(expensesRepositoryMocked.remove).toHaveBeenCalledWith(expect.any(String));
+    expect(expensesRepositoryMocked.remove).toHaveBeenCalledWith({ id: expect.any(String), user_id: userIdMock });
   });
 });

--- a/apps/api/src/modules/Expense/domain/services/__tests__/CreateExpenseService.spec.ts
+++ b/apps/api/src/modules/Expense/domain/services/__tests__/CreateExpenseService.spec.ts
@@ -79,6 +79,6 @@ describe('CreateExpenseService use case - Unit test', () => {
         purchase_date: '2024-09-17',
       }),
     ).rejects.toBeInstanceOf(AppError);
-    expect(expensesRepositoryMocked.remove).toHaveBeenCalledWith({ id: expect.any(String), user_id: userIdMock });
+    expect(expensesRepositoryMocked.remove).toHaveBeenCalledWith({ id: expect.any(String) });
   });
 });

--- a/apps/api/src/modules/Expense/domain/services/__tests__/RemoveExpenseService.spec.ts
+++ b/apps/api/src/modules/Expense/domain/services/__tests__/RemoveExpenseService.spec.ts
@@ -2,13 +2,17 @@ import 'reflect-metadata';
 
 import { RemoveExpenseService } from '../RemoveExpenseService';
 import { IExpensesRepository } from '../../repositories/IExpensesRepository';
+import { IExpensesMonthRepository } from '../../repositories/IExpensesInMonthRepository';
 
 const expensesRepositoryMocked = {
-  findById: jest.fn(),
-  remove: jest.fn(),
+  remove: jest.fn().mockResolvedValue(true),
+};
+const expensesMonthRepositoryMocked = {
+  remove: jest.fn().mockResolvedValue(true),
 };
 const removeExpenseService = new RemoveExpenseService(
   expensesRepositoryMocked as unknown as IExpensesRepository,
+  expensesMonthRepositoryMocked as unknown as IExpensesMonthRepository,
 );
 
 describe('RemoveExpenseService - Unit Test', () => {
@@ -17,22 +21,46 @@ describe('RemoveExpenseService - Unit Test', () => {
   });
 
   it('should be able to remove expense', async () => {
-    expensesRepositoryMocked.findById.mockResolvedValueOnce(true);
     await removeExpenseService.execute({
       expense_id: 'fake-expense-id',
       user_id: 'fake-user-id',
+      is_only_one: false,
     });
 
-    expect(expensesRepositoryMocked.remove).toHaveBeenCalledWith('fake-expense-id');
+    expect(expensesRepositoryMocked.remove).toHaveBeenCalledWith({ id: 'fake-expense-id', user_id: 'fake-user-id' });
   });
 
   it('should not be able to remove non existing expense', async () => {
+    expensesRepositoryMocked.remove.mockResolvedValueOnce(false);
     const removeExpenseServiceOutput = await removeExpenseService.execute({
       expense_id: 'non-exists-expense-id',
       user_id: 'fake-user-id',
+      is_only_one: false
     });
 
     expect(removeExpenseServiceOutput).toEqual(false);
     expect(expensesRepositoryMocked.remove).not.toHaveBeenCalledWith('fake-expense-id');
+  });
+
+  it('should be able to remove one parcel of expense', async () => {
+    await removeExpenseService.execute({
+      expense_id: 'fake-expense-month-id',
+      user_id: 'fake-user-id',
+      is_only_one: true,
+    });
+
+    expect(expensesMonthRepositoryMocked.remove).toHaveBeenCalledWith({ id: 'fake-expense-month-id', user_id: 'fake-user-id' });
+  });
+
+  it('should not be able to remove non existing parcel of expense month', async () => {
+    expensesMonthRepositoryMocked.remove.mockResolvedValueOnce(false);
+    const removeExpenseMonthServiceOutput = await removeExpenseService.execute({
+      expense_id: 'non-exists-expense-month-id',
+      user_id: 'fake-user-id',
+      is_only_one: true
+    });
+
+    expect(removeExpenseMonthServiceOutput).toEqual(false);
+    expect(expensesMonthRepositoryMocked.remove).not.toHaveBeenCalledWith({ id: 'fake-expense-month-id', user_id: 'fake-user-id' });
   });
 });

--- a/apps/api/src/modules/Expense/domain/services/__tests__/RemoveExpenseService.spec.ts
+++ b/apps/api/src/modules/Expense/domain/services/__tests__/RemoveExpenseService.spec.ts
@@ -3,12 +3,16 @@ import 'reflect-metadata';
 import { RemoveExpenseService } from '../RemoveExpenseService';
 import { IExpensesRepository } from '../../repositories/IExpensesRepository';
 import { IExpensesMonthRepository } from '../../repositories/IExpensesInMonthRepository';
+import AppError from '@shared/errors/AppError';
 
 const expensesRepositoryMocked = {
+  findById: jest.fn().mockResolvedValue(true),
   remove: jest.fn().mockResolvedValue(true),
 };
 const expensesMonthRepositoryMocked = {
   remove: jest.fn().mockResolvedValue(true),
+  findById: jest.fn().mockResolvedValue(true),
+  fetchByExpenseId: jest.fn().mockResolvedValue([[], 2])
 };
 const removeExpenseService = new RemoveExpenseService(
   expensesRepositoryMocked as unknown as IExpensesRepository,
@@ -27,19 +31,19 @@ describe('RemoveExpenseService - Unit Test', () => {
       is_only_one: false,
     });
 
-    expect(expensesRepositoryMocked.remove).toHaveBeenCalledWith({ id: 'fake-expense-id', user_id: 'fake-user-id' });
+    expect(expensesRepositoryMocked.remove).toHaveBeenCalledWith({ id: 'fake-expense-id' });
   });
 
   it('should not be able to remove non existing expense', async () => {
-    expensesRepositoryMocked.remove.mockResolvedValueOnce(false);
-    const removeExpenseServiceOutput = await removeExpenseService.execute({
-      expense_id: 'non-exists-expense-id',
-      user_id: 'fake-user-id',
-      is_only_one: false
-    });
+    expensesRepositoryMocked.findById.mockResolvedValueOnce(null);
 
-    expect(removeExpenseServiceOutput).toEqual(false);
-    expect(expensesRepositoryMocked.remove).not.toHaveBeenCalledWith('fake-expense-id');
+    await expect(
+      removeExpenseService.execute({
+        expense_id: 'non-exists-expense-id',
+        user_id: 'fake-user-id',
+        is_only_one: false
+      })
+    ).rejects.toBeInstanceOf(AppError);
   });
 
   it('should be able to remove one parcel of expense', async () => {
@@ -49,18 +53,37 @@ describe('RemoveExpenseService - Unit Test', () => {
       is_only_one: true,
     });
 
-    expect(expensesMonthRepositoryMocked.remove).toHaveBeenCalledWith({ id: 'fake-expense-month-id', user_id: 'fake-user-id' });
+    expect(expensesMonthRepositoryMocked.remove).toHaveBeenCalledWith({ id: 'fake-expense-month-id' });
   });
 
   it('should not be able to remove non existing parcel of expense month', async () => {
-    expensesMonthRepositoryMocked.remove.mockResolvedValueOnce(false);
+    expensesMonthRepositoryMocked.findById.mockResolvedValueOnce(false);
+
+    await expect(
+      removeExpenseService.execute({
+        expense_id: 'non-exists-expense-month-id',
+        user_id: 'fake-user-id',
+        is_only_one: true
+      })
+    ).rejects.toBeInstanceOf(AppError);
+  });
+
+  it('should be able to remove one parcel of expense and if it is the last one, remove father expense too', async () => {
+    const fakeExpenseMonth = {
+      id: 'fake-expense-month-id',
+      user_id: 'fake-user-id',
+      expense_id: 'fake-expense-id',
+    }
+    expensesMonthRepositoryMocked.fetchByExpenseId.mockResolvedValueOnce([[fakeExpenseMonth], 1]);
+    expensesMonthRepositoryMocked.findById.mockResolvedValueOnce(fakeExpenseMonth);
     const removeExpenseMonthServiceOutput = await removeExpenseService.execute({
-      expense_id: 'non-exists-expense-month-id',
+      expense_id: 'fake-expense-month-id',
       user_id: 'fake-user-id',
       is_only_one: true
-    });
+     });
 
-    expect(removeExpenseMonthServiceOutput).toEqual(false);
-    expect(expensesMonthRepositoryMocked.remove).not.toHaveBeenCalledWith({ id: 'fake-expense-month-id', user_id: 'fake-user-id' });
-  });
+     expect(removeExpenseMonthServiceOutput).toEqual(true);
+     expect(expensesMonthRepositoryMocked.remove).toHaveBeenCalledWith({ id: 'fake-expense-month-id' });
+     expect(expensesRepositoryMocked.remove).toHaveBeenCalledWith({ id: 'fake-expense-id' });
+  })
 });

--- a/apps/api/src/modules/Expense/infra/http/controllers/ExpensesController.ts
+++ b/apps/api/src/modules/Expense/infra/http/controllers/ExpensesController.ts
@@ -73,7 +73,7 @@ export class ExpensesController {
     const result = await removeExpenseService.execute({
       expense_id,
       user_id,
-      is_only_one: Boolean(is_only_one),
+      is_only_one: Boolean(Number(is_only_one)),
     });
 
     return response.status(200).json(result);

--- a/apps/api/src/modules/Expense/infra/http/controllers/ExpensesController.ts
+++ b/apps/api/src/modules/Expense/infra/http/controllers/ExpensesController.ts
@@ -64,13 +64,16 @@ export class ExpensesController {
   }
 
   public async delete(request: Request, response: Response): Promise<Response> {
-    const { id } = request.user;
+    const { id: user_id } = request.user;
     const { id: expense_id } = request.params;
+    requestValidations.throwIfPropertyNotExists(request.query, 'is_only_one')
 
+    const { is_only_one } = request.query;
     const removeExpenseService = container.resolve(RemoveExpenseService);
     const result = await removeExpenseService.execute({
       expense_id,
-      user_id: id,
+      user_id,
+      is_only_one: Boolean(is_only_one),
     });
 
     return response.status(200).json(result);

--- a/apps/api/src/modules/Expense/infra/typeorm/repositories/ExpensesMonthRepository.ts
+++ b/apps/api/src/modules/Expense/infra/typeorm/repositories/ExpensesMonthRepository.ts
@@ -1,7 +1,7 @@
 import { Repository } from 'typeorm';
 
 import { DataSourceConfiguration } from '@shared/infra/typeorm/bootstrap';
-import { FindByIdInput, FindByIdOutput, IExpensesMonthRepository, UpdateExpenseMonthInput } from '@modules/Expense/domain/repositories/IExpensesInMonthRepository';
+import { FindByIdInput, FindByIdOutput, IExpensesMonthRepository, RemoveExpenseMonthInput, UpdateExpenseMonthInput } from '@modules/Expense/domain/repositories/IExpensesInMonthRepository';
 import { ExpenseMonthMapper } from '../entities/ExpenseMonthMapper';
 import { ExpenseMonth } from '@modules/Expense/domain/models/ExpenseMonth';
 
@@ -60,5 +60,16 @@ export class ExpensesMonthRepository implements IExpensesMonthRepository {
 
   public async update({ id, data }: UpdateExpenseMonthInput): Promise<void> {
     await this.repository.save({ ...data, id });
+  }
+
+  public async remove({ id, user_id }: RemoveExpenseMonthInput): Promise<boolean> {
+    const result = await this.repository.delete({
+      id,
+      expense: {
+        user_id
+      }
+    });
+
+    return !!result?.affected;
   }
 }

--- a/apps/api/src/modules/Expense/infra/typeorm/repositories/ExpensesMonthRepository.ts
+++ b/apps/api/src/modules/Expense/infra/typeorm/repositories/ExpensesMonthRepository.ts
@@ -1,7 +1,7 @@
 import { Repository } from 'typeorm';
 
 import { DataSourceConfiguration } from '@shared/infra/typeorm/bootstrap';
-import { FindByIdInput, FindByIdOutput, IExpensesMonthRepository, RemoveExpenseMonthInput, UpdateExpenseMonthInput } from '@modules/Expense/domain/repositories/IExpensesInMonthRepository';
+import { FetchByExpenseIdInput, FetchByExpenseIdOutput, FindByIdInput, FindByIdOutput, IExpensesMonthRepository, RemoveExpenseMonthInput, UpdateExpenseMonthInput } from '@modules/Expense/domain/repositories/IExpensesInMonthRepository';
 import { ExpenseMonthMapper } from '../entities/ExpenseMonthMapper';
 import { ExpenseMonth } from '@modules/Expense/domain/models/ExpenseMonth';
 
@@ -62,14 +62,19 @@ export class ExpensesMonthRepository implements IExpensesMonthRepository {
     await this.repository.save({ ...data, id });
   }
 
-  public async remove({ id, user_id }: RemoveExpenseMonthInput): Promise<boolean> {
+  public async remove({ id }: RemoveExpenseMonthInput): Promise<boolean> {
     const result = await this.repository.delete({
       id,
-      expense: {
-        user_id
-      }
     });
 
     return !!result?.affected;
+  }
+
+  public async fetchByExpenseId({ expense_id }: FetchByExpenseIdInput): Promise<FetchByExpenseIdOutput> {
+    return await this.repository.findAndCount({
+      where: {
+        expense_id,
+       },
+    })
   }
 }

--- a/apps/api/src/modules/Expense/infra/typeorm/repositories/ExpensesRepository.ts
+++ b/apps/api/src/modules/Expense/infra/typeorm/repositories/ExpensesRepository.ts
@@ -1,7 +1,7 @@
 import { Repository } from 'typeorm';
 
 import { DataSourceConfiguration } from '@infra/typeorm/bootstrap';
-import { IExpensesRepository, UpdateExpenseInput } from '@modules/Expense/domain/repositories/IExpensesRepository';
+import { IExpensesRepository, RemoveExpenseInput, UpdateExpenseInput } from '@modules/Expense/domain/repositories/IExpensesRepository';
 import { ExpenseMapper } from '../entities/ExpenseMapper';
 import { Expense } from '@modules/Expense/domain/models/Expense';
 
@@ -41,9 +41,10 @@ export class ExpensesRepository implements IExpensesRepository {
     });
   }
 
-  public async remove(id: string): Promise<boolean> {
+  public async remove({ id, user_id }: RemoveExpenseInput): Promise<boolean> {
     const result = await this.repository.delete({
       id,
+      user_id,
     });
 
     return !!result?.affected;

--- a/apps/api/src/modules/Expense/infra/typeorm/repositories/ExpensesRepository.ts
+++ b/apps/api/src/modules/Expense/infra/typeorm/repositories/ExpensesRepository.ts
@@ -1,7 +1,7 @@
 import { Repository } from 'typeorm';
 
 import { DataSourceConfiguration } from '@infra/typeorm/bootstrap';
-import { IExpensesRepository, RemoveExpenseInput, UpdateExpenseInput } from '@modules/Expense/domain/repositories/IExpensesRepository';
+import { FindByIdInput, IExpensesRepository, RemoveExpenseInput, UpdateExpenseInput } from '@modules/Expense/domain/repositories/IExpensesRepository';
 import { ExpenseMapper } from '../entities/ExpenseMapper';
 import { Expense } from '@modules/Expense/domain/models/Expense';
 
@@ -32,19 +32,18 @@ export class ExpensesRepository implements IExpensesRepository {
     });
   }
 
-  public async findById(id: string, userId: string): Promise<ExpenseMapper | null> {
+  public async findById({ id, user_id }: FindByIdInput): Promise<ExpenseMapper | null> {
     return this.repository.findOne({
       where: {
         id,
-        user_id: userId,
+        user_id,
       },
     });
   }
 
-  public async remove({ id, user_id }: RemoveExpenseInput): Promise<boolean> {
+  public async remove({ id }: RemoveExpenseInput): Promise<boolean> {
     const result = await this.repository.delete({
       id,
-      user_id,
     });
 
     return !!result?.affected;

--- a/apps/web/src/components/Button/Button.styles.ts
+++ b/apps/web/src/components/Button/Button.styles.ts
@@ -41,6 +41,15 @@ const BUTTON_VARIANT_MAPPER = {
 			background-color: ${({ theme }) => theme.colors.green100};
 		}
 	`,
+	danger: css`
+		background-color: ${({ theme }) => theme.colors.red700};
+		color: ${({ theme }) => theme.colors.white};
+		font-weight: 600;
+
+		&:not(:disabled):hover {
+			background-color: ${({ theme }) => theme.colors.red900};
+		}
+	`,
 };
 
 const BUTTON_SIZE_MAPPER = {

--- a/apps/web/src/components/Button/Button.tsx
+++ b/apps/web/src/components/Button/Button.tsx
@@ -9,7 +9,7 @@ export interface ButtonContainerProps {
 	 * Variação de estilos do botão
 	 * @default solid
 	 */
-	variant?: 'solid' | 'outline' | 'ghost' | 'link';
+	variant?: 'solid' | 'outline' | 'ghost' | 'link' | 'danger';
 	/**
 	 * Variação de tamanho do botão
 	 * @default md

--- a/apps/web/src/hooks/api/expenses/useDeleteExpense.api.ts
+++ b/apps/web/src/hooks/api/expenses/useDeleteExpense.api.ts
@@ -1,13 +1,21 @@
-import { UseMutationResult, useMutation, useQueryClient } from 'react-query';
+import { useMutation, useQueryClient } from 'react-query';
 import { toast } from 'react-toastify';
 
 import { httpClient } from '@/providers/HTTPClient';
 
-export function useDeleteExpenseApi(expenseId: string): UseMutationResult {
+export interface UseDeleteExpenseApiInput {
+	expenseId: string;
+	/** Define se será excluido uma parcela especifica ou todas. Apesar de ser um boolean, o valor trafegado é 0 ou 1 porque é um valor
+	 * de query params da url.
+	 */
+	isDeleteOne?: 0 | 1;
+}
+
+export function useDeleteExpenseApi() {
 	const queryClient = useQueryClient();
 	return useMutation(
-		async () => {
-			const { data } = await httpClient.delete(`/expenses/${expenseId}`);
+		async ({ expenseId, isDeleteOne = 0 }: UseDeleteExpenseApiInput) => {
+			const { data } = await httpClient.delete(`/expenses/${expenseId}?is_only_one=${isDeleteOne}`);
 			if (!data) throw new Error('Erro ao deletar despesa.');
 		},
 		{

--- a/apps/web/src/pages/home/components/ConfirmDeleteExpenseModal/ConfirmDeleteExpenseModal.styles.ts
+++ b/apps/web/src/pages/home/components/ConfirmDeleteExpenseModal/ConfirmDeleteExpenseModal.styles.ts
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+
+import { Button } from '@/components/Button';
+
+export const ConfirmDeleteExpenseMessage = styled.span`
+	font-size: 1rem;
+	color: ${({ theme }) => theme.colors.gray600};
+`;
+
+export const ConfirmDeleteExpenseFooterContainer = styled.footer`
+	display: flex;
+	justify-content: flex-end;
+	margin-top: 2rem;
+	gap: 0.5rem;
+`;
+
+export const DeleteAllParcelsButton = styled(Button)`
+	color: ${({ theme }) => theme.colors.red700};
+	border-color: ${({ theme }) => theme.colors.red700};
+
+	&:not(:disabled):hover {
+		background-color: ${({ theme }) => theme.colors.red700};
+	}
+`;

--- a/apps/web/src/pages/home/components/ConfirmDeleteExpenseModal/ConfirmDeleteExpenseModal.tsx
+++ b/apps/web/src/pages/home/components/ConfirmDeleteExpenseModal/ConfirmDeleteExpenseModal.tsx
@@ -1,0 +1,63 @@
+import { BaseModal, Button } from '@/components';
+import { ExpenseInMonth } from '@/models/ExpenseInMonth';
+import { DeleteExpenseFunction } from '../../hooks/useDashboard';
+
+import {
+	ConfirmDeleteExpenseFooterContainer,
+	ConfirmDeleteExpenseMessage,
+	DeleteAllParcelsButton,
+} from './ConfirmDeleteExpenseModal.styles';
+
+interface ConfirmDeleteExpenseModalProps {
+	onDeleteExpense: DeleteExpenseFunction;
+	expense: ExpenseInMonth | null;
+	isOpen: boolean;
+	onClose: () => void;
+}
+
+export function ConfirmDeleteExpenseModal({
+	onDeleteExpense,
+	isOpen,
+	onClose,
+	expense,
+}: ConfirmDeleteExpenseModalProps) {
+	if (!expense) {
+		return null;
+	}
+	const { executeDelete, isDeleting } = onDeleteExpense();
+
+	const hasMultipleParcels = expense?.quantityParcel > 1;
+
+	async function handleDelete(isDeleteOne = false) {
+		await executeDelete({
+			expenseId: isDeleteOne ? String(expense?.id) : String(expense?.expenseId),
+			isDeleteOne: isDeleteOne ? 1 : 0,
+		});
+		onClose();
+	}
+
+	function handleClose() {
+		return isDeleting ? undefined : onClose();
+	}
+
+	return (
+		<BaseModal open={isOpen} onClose={handleClose} title="Excluir despesa">
+			<ConfirmDeleteExpenseMessage>
+				Você tem certeza que deseja <strong>excluir</strong> a despesa? Essa ação não pode ser desfeita.
+			</ConfirmDeleteExpenseMessage>
+			<ConfirmDeleteExpenseFooterContainer>
+				<Button variant="link" onClick={handleClose}>
+					Cancelar
+				</Button>
+				{hasMultipleParcels && (
+					<DeleteAllParcelsButton variant="outline" isLoading={isDeleting} onClick={() => handleDelete(false)}>
+						Excluir todas as parcelas
+					</DeleteAllParcelsButton>
+				)}
+				<Button variant="danger" isLoading={isDeleting} onClick={() => handleDelete(true)}>
+					{hasMultipleParcels ? 'Excluir apenas esta parcela' : 'Excluir parcela'}
+				</Button>
+			</ConfirmDeleteExpenseFooterContainer>
+		</BaseModal>
+	);
+}

--- a/apps/web/src/pages/home/components/ExpenseDetailsModal/ExpenseDetailsModal.styles.ts
+++ b/apps/web/src/pages/home/components/ExpenseDetailsModal/ExpenseDetailsModal.styles.ts
@@ -1,8 +1,6 @@
 import { CheckCircle, Trash } from 'phosphor-react';
 import styled from 'styled-components';
 
-import { Button } from '@/components/Button';
-
 interface IExpensePaidIconProps {
 	isPaid: boolean;
 }
@@ -142,12 +140,6 @@ export const Divider = styled.hr`
 	border-top: 1px solid ${props => props.theme.colors.gray100};
 	margin: 1rem 0;
 	padding: 0;
-`;
-
-export const RemoveExpenseButton = styled(Button).attrs({
-	variant: 'ghost',
-})`
-	background-color: ${props => props.theme.colors.red100};
 `;
 
 export const ExpensePaidIcon = styled(CheckCircle).attrs({

--- a/apps/web/src/pages/home/components/ExpenseDetailsModal/ExpenseDetailsModal.tsx
+++ b/apps/web/src/pages/home/components/ExpenseDetailsModal/ExpenseDetailsModal.tsx
@@ -9,7 +9,6 @@ import { dateFormat } from '@/helpers/dateFormat';
 import { formatParcel } from '@/helpers/formatParcel';
 
 import {
-	DeleteExpenseIcon,
 	Divider,
 	ExpenseAmountDetails,
 	ExpenseAmountDetailsItem,
@@ -18,43 +17,28 @@ import {
 	ExpenseDescription,
 	ExpenseDescriptionAndCardDetails,
 	ExpensePaidIcon,
-	RemoveExpenseButton,
 } from './ExpenseDetailsModal.styles';
-
-export interface IDeleteExpenseResponse {
-	isDeleting: boolean;
-	executeDelete: () => Promise<void>;
-}
 
 interface IExpenseDetailsModalProps {
 	isOpenModal: boolean;
 	onClose: () => void;
 	expenseInMonth: ExpenseInMonth | null;
-	deleteExpense: (expenseId: string) => IDeleteExpenseResponse;
 }
 
 export default function ExpenseDetailsModal({
 	expenseInMonth,
 	isOpenModal,
 	onClose,
-	deleteExpense,
 }: Readonly<IExpenseDetailsModalProps>) {
 	if (!expenseInMonth) return null;
 
 	const { expense } = expenseInMonth;
-	const { executeDelete, isDeleting } = deleteExpense(expenseInMonth?.expenseId);
 
 	const expenseTotalAmountFormatted = formatCurrency(expense?.amount);
 	const expenseParcelAmountFormatted = formatCurrency(expenseInMonth?.valueParcel);
 	const parcelsFormatted = formatParcel(expenseInMonth?.currentParcel, expenseInMonth?.quantityParcel);
 	const expenseCreatedAtFormatted = dateFormat(new Date(expense?.createdAt ?? new Date()), 'dd/MM/yyyy');
 	const expenseIdCut = `${expenseInMonth?.expenseId?.slice(0, 20)}...`;
-
-	async function handleDeleteExpense() {
-		if (!expenseInMonth?.expenseId) return null;
-		executeDelete();
-		onClose();
-	}
 
 	function makeParcelSection() {
 		if (expense?.isRecurring) {
@@ -90,12 +74,6 @@ export default function ExpenseDetailsModal({
 					<p>
 						<ExpensePaidIcon isPaid={expenseInMonth?.isPaid ?? false} />
 					</p>
-				</div>
-				<div>
-					<span>Remover?</span>
-					<RemoveExpenseButton size="xs" onClick={handleDeleteExpense} isLoading={isDeleting}>
-						<DeleteExpenseIcon />
-					</RemoveExpenseButton>
 				</div>
 			</ExpenseBaseDetails>
 			<ExpenseAmountDetails>

--- a/apps/web/src/pages/home/components/ExpenseDetailsModal/index.ts
+++ b/apps/web/src/pages/home/components/ExpenseDetailsModal/index.ts
@@ -1,2 +1,1 @@
 export { default as ExpenseDetailsModal } from './ExpenseDetailsModal';
-export type { IDeleteExpenseResponse } from './ExpenseDetailsModal';

--- a/apps/web/src/pages/home/components/ExpensesTable/ExpensesTable.tsx
+++ b/apps/web/src/pages/home/components/ExpensesTable/ExpensesTable.tsx
@@ -14,10 +14,13 @@ import { ExpenseInMonth } from '@/models/ExpenseInMonth';
 import { formatCurrency } from '@/helpers/formatCurrency';
 import { formatParcel } from '@/helpers/formatParcel';
 
-import { ExpenseDetailsModal, IDeleteExpenseResponse } from '../ExpenseDetailsModal';
+import { ExpenseDetailsModal } from '../ExpenseDetailsModal';
 import { expensesTableColumns } from '../../constants/tableColumns';
 
 import { DeleteOptionButton, FilterButton, FilterContainer, OptionButtonsContainer } from './ExpensesTable.styles';
+import { DeleteExpenseFunction } from '../../hooks/useDashboard';
+import { useModal } from '@/hooks/useModal';
+import { ConfirmDeleteExpenseModal } from '../ConfirmDeleteExpenseModal/ConfirmDeleteExpenseModal';
 
 export interface IExpensesTableData {
 	name: string;
@@ -35,13 +38,14 @@ export interface IFetchExpensesResponse {
 }
 interface IExpensesTableProps {
 	fetchExpenses: () => IFetchExpensesResponse;
-	deleteExpense: (expenseId: string) => IDeleteExpenseResponse;
+	deleteExpense: DeleteExpenseFunction;
 }
 
 export default function ExpensesTable({ fetchExpenses, deleteExpense }: Readonly<IExpensesTableProps>) {
 	const [isOpenExpenseDetailsModal, setIsOpenExpenseDetailsModal] = useState(false);
 	const [selectedExpense, setSelectedExpense] = useState<ExpenseInMonth | null>(null);
 
+	const confirmDeleteExpenseModal = useModal(false);
 	const { isFetchingExpenses, expensesInMonth } = fetchExpenses();
 
 	function handleSelectExpense(expenseInMonth: ExpenseInMonth) {
@@ -90,7 +94,10 @@ export default function ExpensesTable({ fetchExpenses, deleteExpense }: Readonly
 							type="button"
 							variant="ghost"
 							size="sm"
-							onClick={() => handleSelectExpense(expenseInMonth)}
+							onClick={() => {
+								setSelectedExpense(expenseInMonth);
+								confirmDeleteExpenseModal.open();
+							}}
 						>
 							<TrashIcon />
 						</DeleteOptionButton>
@@ -126,7 +133,12 @@ export default function ExpensesTable({ fetchExpenses, deleteExpense }: Readonly
 				isOpenModal={isOpenExpenseDetailsModal}
 				onClose={() => setIsOpenExpenseDetailsModal(false)}
 				expenseInMonth={selectedExpense}
-				deleteExpense={deleteExpense}
+			/>
+			<ConfirmDeleteExpenseModal
+				isOpen={confirmDeleteExpenseModal.isOpen}
+				onClose={confirmDeleteExpenseModal.close}
+				onDeleteExpense={deleteExpense}
+				expense={selectedExpense}
 			/>
 		</>
 	);

--- a/apps/web/src/pages/home/hooks/useDashboard.ts
+++ b/apps/web/src/pages/home/hooks/useDashboard.ts
@@ -4,11 +4,15 @@ import { useContextSelector } from 'use-context-selector';
 import { selectedMonthYearContext } from '@/contexts';
 import { useFetchExpensesSummaryApi } from '@/hooks/api/expenses/useFetchExpensesSummary.api';
 import { useFetchExpensesMonthApi } from '@/hooks/api/expenses/useFetchExpensesMonth.api';
-import { useDeleteExpenseApi } from '@/hooks/api/expenses/useDeleteExpense.api';
+import { useDeleteExpenseApi, UseDeleteExpenseApiInput } from '@/hooks/api/expenses/useDeleteExpense.api';
 
 import type { IFetchSummaryResponse } from '../components/Summary';
 import type { IFetchExpensesResponse } from '../components/ExpensesTable';
-import type { IDeleteExpenseResponse } from '../components/ExpenseDetailsModal';
+
+export type DeleteExpenseFunction = () => {
+	isDeleting: boolean;
+	executeDelete: (args: UseDeleteExpenseApiInput) => Promise<void>;
+};
 
 export function useDashboard() {
 	const handleRestoreToCurrentMonthAndYear = useContextSelector(
@@ -36,14 +40,14 @@ export function useDashboard() {
 		};
 	}
 
-	function deleteExpense(expenseId: string): IDeleteExpenseResponse {
-		const { mutateAsync, isLoading } = useDeleteExpenseApi(expenseId);
+	const deleteExpense: DeleteExpenseFunction = () => {
+		const { mutateAsync, isLoading } = useDeleteExpenseApi();
 
 		return {
 			isDeleting: isLoading,
-			executeDelete: mutateAsync as () => Promise<void>,
+			executeDelete: mutateAsync as (args: UseDeleteExpenseApiInput) => Promise<void>,
 		};
-	}
+	};
 
 	return {
 		handleRestoreToCurrentMonthAndYear,


### PR DESCRIPTION
### Contém nessa PR 📝 
- Lógica para remoção de uma única parcela da despesa
- Lógica para remoção para todas as parcelas da despesa
- Lógica para remoção da despesa pai quando a despesa a ser excluída for a última existente
- Adicionado um novo modal ao _web_ para dar a escolha para o usuário excluir todas ou apenas uma parcela da despesa
- Adicionado uma nova variação (_danger_) no componente Button. Essa variação segue a linha de estilo da variante _solid_ porém como cor primária assume o _red.700_ da folha de tema.

### Testes 🧪 
![image](https://github.com/user-attachments/assets/59da4046-0257-4939-b2c9-0cace7bbb0da)

_Obs: Foram adicionados apenas testes unitários a nível de api_