### PR TITLE
FA-10 - Correção da opção de boleto bancário no cadastro de meios de pagamento

### DIFF
--- a/apps/web/src/pages/registrations/cards/CreateCardsPage.tsx
+++ b/apps/web/src/pages/registrations/cards/CreateCardsPage.tsx
@@ -13,7 +13,7 @@ export default function CreateCardsPage() {
 
 	const {
 		register,
-		formState: { errors, isValid },
+		formState: { errors },
 		handleSubmit,
 		control,
 	} = formSchema;
@@ -80,20 +80,6 @@ export default function CreateCardsPage() {
 								</InputLabel>
 							</Column>
 						</Row>
-						<Row>
-							<Column>
-								<InputLabel>
-									Limite do cartão:
-									<TextInput
-										prefix="R$"
-										type="number"
-										placeholder="1000"
-										error={errors.creditLimit?.message}
-										{...register('creditLimit', { valueAsNumber: true })}
-									/>
-								</InputLabel>
-							</Column>
-						</Row>
 					</RegisterCardsForm>
 				</LayoutBox.Content>
 				<LayoutBox.Footer>
@@ -101,7 +87,6 @@ export default function CreateCardsPage() {
 						<ActionButtons>
 							<ActionButtons.Cancel onClick={handleCancel} />
 							<ActionButtons.Submit
-								isDisabled={!isValid}
 								isLoading={isCreatingCard}
 								onClick={handleSubmit(handleCreateCard)}
 								spinnerConfig={{ mode: 'light', size: 'sm' }}

--- a/apps/web/src/pages/registrations/cards/constants/availableCardsOptions.ts
+++ b/apps/web/src/pages/registrations/cards/constants/availableCardsOptions.ts
@@ -1,5 +1,5 @@
 export const AVAILABLE_CARDS_OPTIONS = [
 	{ value: 'visa', label: 'Visa' },
 	{ value: 'mastercard', label: 'Mastercard' },
-	{ value: 'none', label: 'Sem bandeira' },
+	{ value: 'bank_slip', label: 'Boleto Bancário' },
 ];

--- a/apps/web/src/pages/registrations/cards/constants/formSchema.ts
+++ b/apps/web/src/pages/registrations/cards/constants/formSchema.ts
@@ -1,17 +1,22 @@
 import * as Yup from 'yup';
 import type { InferType } from 'yup';
+import { AVAILABLE_CARDS_OPTIONS } from './availableCardsOptions';
 
 export const createCardFormSchema = Yup.object().shape({
 	name: Yup.string().required('Campo obrigatório'),
 	flag: Yup.object()
 		.shape({
 			label: Yup.string().required(),
-			value: Yup.string().required(),
+			value: Yup.string()
+				.oneOf(
+					AVAILABLE_CARDS_OPTIONS.map(option => option.value),
+					'Campo inválido',
+				)
+				.required(),
 		})
 		.required('Campo obrigatório'),
-	creditLimit: Yup.number().positive(),
-	dueDay: Yup.number().positive().required('Campo obrigatório'),
-	turningDay: Yup.number().positive().required('Campo obrigatório'),
+	dueDay: Yup.number().positive('Campo inválido').required('Campo obrigatório'),
+	turningDay: Yup.number().positive('Campo inválido').required('Campo obrigatório'),
 });
 
 export type CreateCardFieldsType = InferType<typeof createCardFormSchema>;

--- a/apps/web/src/pages/registrations/cards/hooks/useCreateCards.ts
+++ b/apps/web/src/pages/registrations/cards/hooks/useCreateCards.ts
@@ -9,9 +9,6 @@ import { CreateCardFieldsType, createCardFormSchema } from '../constants/formSch
 export function useCreateCards() {
 	const router = useRouter();
 	const formSchema = useForm<CreateCardFieldsType>({
-		defaultValues: {
-			creditLimit: 0,
-		},
 		resolver: yupResolver(createCardFormSchema),
 	});
 	const { mutateAsync, isLoading: isCreating, isSuccess } = useCreateCardApi();


### PR DESCRIPTION
## Contém nessa PR ✍🏻 
- Correção do _value_ referente ao meio de pagamento por boleto bancário.
- Remoção do campo não utilizado "Limite do cartão", esse campo estava visível mas não tinha funcionamento prático.
- Adição de validação no formulário de cadastro de meio de pagamento. Foi adicionado um _enum_ para garantir apenas tipos de meios de pagamentos mapeados.

## Resultado  🎉
![image](https://github.com/user-attachments/assets/07e34427-3c14-408b-be32-c9041efb959c)
