### PR TITLE
FA-12 - Remoção da navegação ao finalizar cadastro de despesa

### DIFF
--- a/apps/web/src/pages/registrations/expenses/hooks/useCreateExpense.ts
+++ b/apps/web/src/pages/registrations/expenses/hooks/useCreateExpense.ts
@@ -1,6 +1,5 @@
 import { useCallback } from 'react';
 import { toast } from 'react-toastify';
-import { useRouter } from 'next/router';
 import { getMonth, getYear } from 'date-fns';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useForm } from 'react-hook-form';
@@ -9,7 +8,6 @@ import { FormExpenseFieldsType, createFormExpenseFormSchema } from '../constants
 import { useCreateExpenseApi } from '@/hooks/api/expenses/useCreateExpense.api';
 
 export function useCreateExpense() {
-	const router = useRouter();
 	const formSchema = useForm<FormExpenseFieldsType>({
 		resolver: yupResolver(createFormExpenseFormSchema(false)),
 		defaultValues: {
@@ -36,7 +34,13 @@ export function useCreateExpense() {
 			manualExpenseDate: data.manualExpenseDate!,
 		});
 		toast.success('Despesa criada com sucesso!');
-		router.push('/');
+		formSchema.resetField('name');
+		formSchema.resetField('category');
+		formSchema.resetField('totalValue');
+		formSchema.resetField('isRecurring');
+		formSchema.resetField('parcelQuantity');
+		formSchema.resetField('parcelValue');
+		formSchema.setFocus('name');
 	}
 
 	const parcelValue =


### PR DESCRIPTION
## Contém nessa PR ✍🏻 
- Remoção do redirecionamento para a dashboard quando uma nova despesa for criada. Isso vai ajudar no cadastro de despesas em sequência.
- Reset de apenas alguns campos do formulário. Os campos de data de compra, data da despesa e meio de pagamento não serão resetados na criação da despesa.
- Foco no _input_ de nome da despesa automaticamente depois do _submit_

## Resultado  🎉
![image](https://github.com/user-attachments/assets/c16a18c2-6219-4d2e-91d7-cc387a9262d0)
