### PR TITLE
FA-14 - Correção do scheduler cron para mapeador de despesas recorrentes

### DIFF
--- a/apps/api/src/shared/infra/scheduler/index.ts
+++ b/apps/api/src/shared/infra/scheduler/index.ts
@@ -2,9 +2,9 @@ import schedule from 'node-schedule';
 import processRecurringExpenses from './scripts/processRecurringExpenses';
 
 /**
- * Esse script deve ser executado todo dia 15º de cada mês.
+ * Esse script deve ser executado todo dia 15º de cada mês às 00:00.
  */
-const processRecurringExpensesJob = schedule.scheduleJob('* * 15 * *', async () => {
+const processRecurringExpensesJob = schedule.scheduleJob('0 0 15 * *', async () => {
   await processRecurringExpenses();
 });
 


### PR DESCRIPTION
## Contém nessa PR ✍🏻 
- Correção do scheduler rodando a todo minuto de todo dia 15. Com a correção a execução acontece todo dia 15 a meia noite.


