### PR TITLE
FA-16 - Implementacão do cadastro de pessoas divisoras [web/api]

### DIFF
--- a/apps/api/src/modules/ShareExpensePerson/domain/models/ShareExpensePerson.ts
+++ b/apps/api/src/modules/ShareExpensePerson/domain/models/ShareExpensePerson.ts
@@ -4,7 +4,7 @@ export class ShareExpensePerson {
   private static readonly schema = z.object({
       id: z.number(),
       name: z.string().min(3).max(20),
-      whatsapp: z.string().length(10),
+      whatsapp: z.string().length(11),
       day_to_send_message: z.enum(['1', '5', '10']).default('5').transform(value => Number(value)),
       user_id: z.string().uuid(),
       created_at: z.date().optional(),
@@ -14,7 +14,7 @@ export class ShareExpensePerson {
     public readonly id?: number;
     public readonly name?: string;
     public readonly user_id?: string;
-    public readonly day_to_send_message?: number;
+    public readonly day_to_send_message?: number | string;
     public readonly whatsapp?: string;
     public readonly created_at?: Date;
     public readonly updated_at?: Date;

--- a/apps/api/src/modules/ShareExpensePerson/domain/models/ShareExpensePerson.ts
+++ b/apps/api/src/modules/ShareExpensePerson/domain/models/ShareExpensePerson.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+
+export class ShareExpensePerson {
+  private static readonly schema = z.object({
+      id: z.number(),
+      name: z.string().min(3).max(20),
+      whatsapp: z.string().length(10),
+      day_to_send_message: z.enum(['1', '5', '10']).default('5'),
+      user_id: z.string().uuid(),
+      created_at: z.date().optional(),
+      updated_at: z.date().optional(),
+    });
+
+    public readonly id?: string;
+    public readonly name?: string;
+    public readonly user_id?: string;
+    public readonly day_to_send_message?: string;
+    public readonly whatsapp?: string;
+    public readonly created_at?: Date;
+    public readonly updated_at?: Date;
+
+    constructor(input: Partial<ShareExpensePerson>, validate: boolean | 'create' | 'partial' = true) {
+      if (validate) {
+        let schema = ShareExpensePerson.schema;
+
+        switch (validate) {
+          case true: {
+            schema.parse(input);
+            break;
+          }
+          case 'create': {
+            const createExpense = schema.partial({
+              id: true,
+            });
+            createExpense.parse(input);
+            break;
+          }
+          case 'partial': {
+            const partialExpense = schema.partial({
+              user_id: true,
+              id: true,
+              day_to_send_message: true,
+              name: true,
+              whatsapp: true,
+            });
+            partialExpense.parse(input);
+            break;
+          }
+        }
+      }
+
+      Object.assign(this, input);
+    }
+}

--- a/apps/api/src/modules/ShareExpensePerson/domain/models/ShareExpensePerson.ts
+++ b/apps/api/src/modules/ShareExpensePerson/domain/models/ShareExpensePerson.ts
@@ -5,16 +5,16 @@ export class ShareExpensePerson {
       id: z.number(),
       name: z.string().min(3).max(20),
       whatsapp: z.string().length(10),
-      day_to_send_message: z.enum(['1', '5', '10']).default('5'),
+      day_to_send_message: z.enum(['1', '5', '10']).default('5').transform(value => Number(value)),
       user_id: z.string().uuid(),
       created_at: z.date().optional(),
       updated_at: z.date().optional(),
     });
 
-    public readonly id?: string;
+    public readonly id?: number;
     public readonly name?: string;
     public readonly user_id?: string;
-    public readonly day_to_send_message?: string;
+    public readonly day_to_send_message?: number;
     public readonly whatsapp?: string;
     public readonly created_at?: Date;
     public readonly updated_at?: Date;

--- a/apps/api/src/modules/ShareExpensePerson/domain/models/__tests__/ShareExpensePerson.spec.ts
+++ b/apps/api/src/modules/ShareExpensePerson/domain/models/__tests__/ShareExpensePerson.spec.ts
@@ -1,0 +1,59 @@
+import { v4 as createUUID } from 'uuid';
+
+import { ShareExpensePerson } from '../ShareExpensePerson';
+import { ZodError } from 'zod';
+
+describe('ShareExpensePerson model - Unit test', () => {
+  it('should be able to create a shareExpensePerson object with validate as true', async () => {
+    const shareExpensePersonOutput = new ShareExpensePerson(
+      {
+        id: 1,
+        name: 'fake-name',
+        day_to_send_message: '5',
+        whatsapp: '55555555555',
+        user_id: createUUID(),
+      },
+      true,
+    );
+
+    expect(shareExpensePersonOutput).toBeInstanceOf(ShareExpensePerson);
+  });
+
+  it('should be able to create a shareExpensePerson object with validate as partial', async () => {
+    const shareExpensePersonOutput = new ShareExpensePerson(
+      {
+        name: 'fake-name',
+        whatsapp: '55555555555',
+      },
+      'partial',
+    );
+
+    expect(shareExpensePersonOutput).toBeInstanceOf(ShareExpensePerson);
+  });
+
+  it('should be able to create a shareExpensePerson object with validate as false', async () => {
+    const incomeOutput = new ShareExpensePerson({}, false);
+
+    expect(incomeOutput).toBeInstanceOf(ShareExpensePerson);
+  });
+
+  it('should not be able to create a shareExpensePerson object with invalid params', async () => {
+    try {
+      new ShareExpensePerson({
+        // @ts-expect-error - Testing invalid params
+        id: createUUID(),
+        whatsapp: '555'
+      });
+    } catch (error) {
+      expect(error).toBeInstanceOf(ZodError);
+      expect((error as ZodError).flatten()).toEqual(
+        expect.objectContaining({
+          fieldErrors: expect.objectContaining({
+            id: ['Expected number, received string'],
+            whatsapp: ['String must contain exactly 11 character(s)'],
+          }),
+        })
+      )
+    }
+  });
+});

--- a/apps/api/src/modules/ShareExpensePerson/domain/repositories/IShareExpensesPersonRepository.ts
+++ b/apps/api/src/modules/ShareExpensePerson/domain/repositories/IShareExpensesPersonRepository.ts
@@ -4,6 +4,6 @@ import { ShareExpensePerson } from "../models/ShareExpensePerson";
 export type FindByNameInput = { name: string, user_id: string }
 
 export interface IShareExpensesPersonRepository {
-  create: (args: ShareExpensePerson) => Promise<ShareExpensePersonMapper>
-  findByName: (args: FindByNameInput) => Promise<ShareExpensePersonMapper[] | null>
+  create: (args: ShareExpensePerson) => Promise<ShareExpensePerson>
+  findByName: (args: FindByNameInput) => Promise<ShareExpensePerson | null>
 }

--- a/apps/api/src/modules/ShareExpensePerson/domain/repositories/ShareExpensesPersonRepository.ts
+++ b/apps/api/src/modules/ShareExpensePerson/domain/repositories/ShareExpensesPersonRepository.ts
@@ -1,3 +1,9 @@
-export interface IShareExpensesPersonRepository {
+import { ShareExpensePersonMapper } from "@modules/ShareExpensePerson/infra/typeorm/entities/ShareExpensePersonMapper";
+import { ShareExpensePerson } from "../models/ShareExpensePerson";
 
+export type FindByNameInput = { name: string, user_id: string }
+
+export interface IShareExpensesPersonRepository {
+  create: (args: ShareExpensePerson) => Promise<ShareExpensePersonMapper>
+  findByName: (args: FindByNameInput) => Promise<ShareExpensePersonMapper[] | null>
 }

--- a/apps/api/src/modules/ShareExpensePerson/domain/repositories/ShareExpensesPersonRepository.ts
+++ b/apps/api/src/modules/ShareExpensePerson/domain/repositories/ShareExpensesPersonRepository.ts
@@ -1,0 +1,3 @@
+export interface IShareExpensesPersonRepository {
+
+}

--- a/apps/api/src/modules/ShareExpensePerson/domain/services/CreateShareExpensePersonService.ts
+++ b/apps/api/src/modules/ShareExpensePerson/domain/services/CreateShareExpensePersonService.ts
@@ -1,0 +1,26 @@
+import { inject } from "tsyringe"
+import { ShareExpensePerson } from "../models/ShareExpensePerson"
+import { IShareExpensesPersonRepository } from "../repositories/ShareExpensesPersonRepository"
+
+interface CreateShareExpensePersonServiceInput {
+  name: string
+  whatsapp: string
+  day_to_send_message: string
+  user_id: string
+}
+interface CreateShareExpensePersonServiceOutput {}
+
+export class CreateShareExpensePersonService {
+  constructor(
+    @inject('ShareExpensesPersonRepository') private readonly shareExpensesPersonRepository: IShareExpensesPersonRepository,
+  ){}
+
+  async execute(props: CreateShareExpensePersonServiceInput) {
+    const shareExpensePersonModel = this.makeShareExpensePersonModel(props)
+    // TODO: Continuar service
+  }
+
+  private makeShareExpensePersonModel(props: ShareExpensePerson) {
+    return new ShareExpensePerson(props, 'create')
+  }
+}

--- a/apps/api/src/modules/ShareExpensePerson/domain/services/CreateShareExpensePersonService.ts
+++ b/apps/api/src/modules/ShareExpensePerson/domain/services/CreateShareExpensePersonService.ts
@@ -1,8 +1,8 @@
-import { inject } from "tsyringe"
+import { inject, injectable } from "tsyringe"
 
 import AppError from "@shared/errors/AppError"
 import { ShareExpensePerson } from "../models/ShareExpensePerson"
-import { IShareExpensesPersonRepository } from "../repositories/ShareExpensesPersonRepository"
+import { IShareExpensesPersonRepository } from "../repositories/IShareExpensesPersonRepository"
 
 interface CreateShareExpensePersonServiceInput {
   name: string
@@ -12,6 +12,7 @@ interface CreateShareExpensePersonServiceInput {
 }
 type CreateShareExpensePersonServiceOutput = Promise<ShareExpensePerson>
 
+@injectable()
 export class CreateShareExpensePersonService {
   constructor(
     @inject('ShareExpensesPersonRepository') private readonly shareExpensesPersonRepository: IShareExpensesPersonRepository,
@@ -21,7 +22,7 @@ export class CreateShareExpensePersonService {
     const shareExpensePersonModel = this.makeShareExpensePersonModel(props)
 
     const peopleWithSameName = await this.shareExpensesPersonRepository.findByName({ name: shareExpensePersonModel.name!, user_id: shareExpensePersonModel.user_id! })
-    if (peopleWithSameName?.length) {
+    if (peopleWithSameName) {
       throw new AppError('[ERROR]: Name of person must be unique.');
     }
 

--- a/apps/api/src/modules/ShareExpensePerson/domain/services/__tests__/CreateShareExpensePersonService.spec.ts
+++ b/apps/api/src/modules/ShareExpensePerson/domain/services/__tests__/CreateShareExpensePersonService.spec.ts
@@ -1,0 +1,45 @@
+import { v4 } from 'uuid'
+import { IShareExpensesPersonRepository } from '../../repositories/IShareExpensesPersonRepository'
+import { CreateShareExpensePersonService } from '../CreateShareExpensePersonService'
+import { ShareExpensePerson } from '../../models/ShareExpensePerson'
+import AppError from '@shared/errors/AppError'
+
+let shareExpensesPersonRepositoryMocked: Partial<IShareExpensesPersonRepository>
+let sut: CreateShareExpensePersonService
+
+const fakeUserId = v4()
+
+describe('CreateShareExpensePersonService service - Uni test', () => {
+  beforeEach(() => {
+    shareExpensesPersonRepositoryMocked = {
+      create: jest.fn(),
+      findByName: jest.fn()
+    }
+    sut = new CreateShareExpensePersonService(shareExpensesPersonRepositoryMocked as unknown as IShareExpensesPersonRepository)
+  })
+
+  it('should be able to create a new share expense person', async() =>{
+    await sut.execute({
+      name: 'fake-name',
+      whatsapp: '55555555555',
+      day_to_send_message: '5',
+      user_id: fakeUserId
+    })
+
+
+    expect(shareExpensesPersonRepositoryMocked.create).toHaveBeenCalled
+  })
+
+  it('should not be able to create a new share expense person if exist an user with same name', async() => {
+    shareExpensesPersonRepositoryMocked.findByName = jest.fn().mockResolvedValueOnce({ name: 'fake-same-name' })
+    await expect(
+      sut.execute({
+        name: 'fake-same-name',
+        whatsapp: '55555555555',
+        day_to_send_message: '5',
+        user_id: fakeUserId
+      })
+    ).rejects.toBeInstanceOf(AppError)
+    expect(shareExpensesPersonRepositoryMocked.create).not.toHaveBeenCalled
+  })
+})

--- a/apps/api/src/modules/ShareExpensePerson/infra/http/controllers/ShareExpensePersonController.ts
+++ b/apps/api/src/modules/ShareExpensePerson/infra/http/controllers/ShareExpensePersonController.ts
@@ -1,0 +1,23 @@
+import type { Request, Response } from 'express';
+import { container } from 'tsyringe';
+
+import { requestValidations } from '@helpers/requestValidations';
+import { CreateShareExpensePersonService } from '@modules/ShareExpensePerson/domain/services/CreateShareExpensePersonService'
+
+export class ShareExpensePersonController {
+  public async create(request: Request, response: Response): Promise<Response> {
+    requestValidations.throwIfEmptyBody(request.body);
+    const { id } = request.user;
+
+    const createShareExpensePersonService = container.resolve(CreateShareExpensePersonService);
+
+    const shareExpensePerson = await createShareExpensePersonService.execute({
+      ...request.body,
+      user_id: id,
+    });
+
+    return response.status(201).json(shareExpensePerson);
+  }
+
+
+}

--- a/apps/api/src/modules/ShareExpensePerson/infra/http/routes/shareExpensePerson.routes.ts
+++ b/apps/api/src/modules/ShareExpensePerson/infra/http/routes/shareExpensePerson.routes.ts
@@ -1,0 +1,13 @@
+import { Router } from 'express';
+
+import { ensureAuthenticated } from '@infra/http/middlewares/ensureAuthenticated';
+import { ShareExpensePersonController } from '../controllers/ShareExpensePersonController';
+
+const shareExpensePersonRouter = Router();
+const shareExpensePersonController = new ShareExpensePersonController();
+
+shareExpensePersonRouter.use(ensureAuthenticated);
+
+shareExpensePersonRouter.post('/', shareExpensePersonController.create);
+
+export default shareExpensePersonRouter;

--- a/apps/api/src/modules/ShareExpensePerson/infra/typeorm/entities/ShareExpensePersonMapper.ts
+++ b/apps/api/src/modules/ShareExpensePerson/infra/typeorm/entities/ShareExpensePersonMapper.ts
@@ -1,0 +1,44 @@
+import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn, JoinColumn, ManyToOne } from 'typeorm'
+
+import { ShareExpensePerson } from "@modules/ShareExpensePerson/domain/models/ShareExpensePerson";
+import { UserMapper } from '@modules/User/infra/typeorm/entities/UserMapper';
+
+@Entity('share_expense_people')
+export class ShareExpensePersonMapper {
+  @PrimaryGeneratedColumn('increment')
+  id: number;
+
+  @Column()
+  name: string;
+
+  @Column()
+  whatsapp: string;
+
+  @Column()
+  day_to_send_message: number;
+
+  @Column()
+  user_id: string;
+
+  @ManyToOne(() => UserMapper)
+  @JoinColumn({ name: 'user_id' })
+  user: UserMapper
+
+  @CreateDateColumn()
+  created_at?: Date;
+
+  @UpdateDateColumn()
+  updated_at?: Date;
+
+  static toModel(data: ShareExpensePersonMapper) {
+    return new ShareExpensePerson({
+      id: data.id,
+      name: data.name,
+      whatsapp: data.whatsapp,
+      day_to_send_message: data.day_to_send_message,
+      user_id: data.user_id,
+      created_at: data.created_at,
+      updated_at: data.updated_at,
+    });
+  }
+}

--- a/apps/api/src/modules/ShareExpensePerson/infra/typeorm/entities/ShareExpensePersonMapper.ts
+++ b/apps/api/src/modules/ShareExpensePerson/infra/typeorm/entities/ShareExpensePersonMapper.ts
@@ -35,7 +35,7 @@ export class ShareExpensePersonMapper {
       id: data.id,
       name: data.name,
       whatsapp: data.whatsapp,
-      day_to_send_message: data.day_to_send_message,
+      day_to_send_message: String(data.day_to_send_message),
       user_id: data.user_id,
       created_at: data.created_at,
       updated_at: data.updated_at,

--- a/apps/api/src/modules/ShareExpensePerson/infra/typeorm/repositories/ShareExpensePersonRepository.ts
+++ b/apps/api/src/modules/ShareExpensePerson/infra/typeorm/repositories/ShareExpensePersonRepository.ts
@@ -1,0 +1,30 @@
+import { Repository } from "typeorm";
+import { ShareExpensePersonMapper } from "../entities/ShareExpensePersonMapper";
+import { DataSourceConfiguration } from "@shared/infra/typeorm/bootstrap";
+import { ShareExpensePerson } from "@modules/ShareExpensePerson/domain/models/ShareExpensePerson";
+import { FindByNameInput, IShareExpensesPersonRepository } from "@modules/ShareExpensePerson/domain/repositories/ShareExpensesPersonRepository";
+
+export class ShareExpensePersonRepository implements IShareExpensesPersonRepository {
+  private repository: Repository<ShareExpensePersonMapper>
+
+  constructor() {
+    this.repository = DataSourceConfiguration.getRepository(ShareExpensePersonMapper)
+  }
+
+  private makeShareExpensePersonMapper(input: ShareExpensePerson): ShareExpensePersonMapper {
+    return Object.assign(new ShareExpensePersonMapper(), input)
+  }
+
+  public async create(args: ShareExpensePerson): Promise<ShareExpensePersonMapper> {
+    const shareExpensePersonMapper = this.makeShareExpensePersonMapper(args)
+    const shareExpensePerson = this.repository.create(shareExpensePersonMapper)
+    await this.repository.save(shareExpensePerson)
+    return shareExpensePerson
+  }
+  public async findByName({ name, user_id }: FindByNameInput): Promise<ShareExpensePersonMapper[] | null> {
+    return this.repository.findBy({
+      name,
+      user_id
+    })
+  }
+}

--- a/apps/api/src/modules/ShareExpensePerson/infra/typeorm/repositories/ShareExpensesPersonRepository.ts
+++ b/apps/api/src/modules/ShareExpensePerson/infra/typeorm/repositories/ShareExpensesPersonRepository.ts
@@ -2,9 +2,9 @@ import { Repository } from "typeorm";
 import { ShareExpensePersonMapper } from "../entities/ShareExpensePersonMapper";
 import { DataSourceConfiguration } from "@shared/infra/typeorm/bootstrap";
 import { ShareExpensePerson } from "@modules/ShareExpensePerson/domain/models/ShareExpensePerson";
-import { FindByNameInput, IShareExpensesPersonRepository } from "@modules/ShareExpensePerson/domain/repositories/ShareExpensesPersonRepository";
+import { FindByNameInput, IShareExpensesPersonRepository } from "@modules/ShareExpensePerson/domain/repositories/IShareExpensesPersonRepository";
 
-export class ShareExpensePersonRepository implements IShareExpensesPersonRepository {
+export class ShareExpensesPersonRepository implements IShareExpensesPersonRepository {
   private repository: Repository<ShareExpensePersonMapper>
 
   constructor() {
@@ -15,16 +15,18 @@ export class ShareExpensePersonRepository implements IShareExpensesPersonReposit
     return Object.assign(new ShareExpensePersonMapper(), input)
   }
 
-  public async create(args: ShareExpensePerson): Promise<ShareExpensePersonMapper> {
+  public async create(args: ShareExpensePerson): Promise<ShareExpensePerson> {
     const shareExpensePersonMapper = this.makeShareExpensePersonMapper(args)
     const shareExpensePerson = this.repository.create(shareExpensePersonMapper)
     await this.repository.save(shareExpensePerson)
-    return shareExpensePerson
+    return ShareExpensePersonMapper.toModel(shareExpensePerson)
   }
-  public async findByName({ name, user_id }: FindByNameInput): Promise<ShareExpensePersonMapper[] | null> {
-    return this.repository.findBy({
+  public async findByName({ name, user_id }: FindByNameInput): Promise<ShareExpensePerson | null> {
+    const mapperFound = await this.repository.findOneBy({
       name,
       user_id
     })
+
+    return mapperFound ? ShareExpensePersonMapper.toModel(mapperFound) : null
   }
 }

--- a/apps/api/src/shared/infra/http/routes/index.ts
+++ b/apps/api/src/shared/infra/http/routes/index.ts
@@ -5,6 +5,7 @@ import authRoutes from '@modules/Auth/infra/http/routes/auth.routes';
 import cardsRoutes from '@modules/Card/infra/http/routes/cards.routes';
 import expensesRoutes from '@modules/Expense/infra/http/routes/expenses.routes';
 import settingsRoutes from '@modules/Settings/infra/http/routes';
+import shareExpensePerson from '@modules/ShareExpensePerson/infra/http/routes/shareExpensePerson.routes'
 
 const routes = Router();
 
@@ -13,5 +14,6 @@ routes.use('/auth', authRoutes);
 routes.use('/cards', cardsRoutes);
 routes.use('/expenses', expensesRoutes);
 routes.use('/settings/incomes', settingsRoutes.incomesRoutes);
+routes.use('/share-people', shareExpensePerson);
 
 export default routes;

--- a/apps/api/src/shared/infra/typeorm/migrations/1738111384959-CreateShareExpensePeopleTable.ts
+++ b/apps/api/src/shared/infra/typeorm/migrations/1738111384959-CreateShareExpensePeopleTable.ts
@@ -1,0 +1,59 @@
+import { MigrationInterface, QueryRunner, Table } from "typeorm";
+
+export class CreateShareExpensePeopleTable1738111384959 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+      await queryRunner.createTable(new Table({
+        name: "share_expense_people",
+        columns: [
+          {
+            name: "id",
+            type: "serial4",
+            isPrimary: true,
+            generationStrategy: "increment"
+          },
+          {
+            name: "name",
+            type: "varchar"
+          },
+          {
+            name: "whatsapp",
+            type: "varchar"
+          },
+          {
+            name: "day_to_send_message",
+            type: "int"
+          },
+          {
+            name: "user_id",
+            type: "uuid"
+          },
+          {
+            name: "created_at",
+            type: "timestamp",
+            default: "now()",
+          },
+          {
+            name: "updated_at",
+            type: "timestamp",
+            default: "now()",
+          }
+        ],
+        foreignKeys: [
+          {
+            name: "fk_config_user",
+            columnNames: ["user_id"],
+            referencedTableName: "users",
+            referencedColumnNames: ["id"],
+            onDelete: "SET NULL",
+            onUpdate: "CASCADE"
+          }
+        ],
+      }))
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+      await queryRunner.dropTable("share_expense_people")
+    }
+
+}

--- a/apps/api/src/shared/ioc/index.ts
+++ b/apps/api/src/shared/ioc/index.ts
@@ -16,6 +16,9 @@ import { ExpensesMonthRepository } from '@modules/Expense/infra/typeorm/reposito
 import type { IIncomesRepository } from '@modules/Settings/domain/repositories/IIncomeRepository';
 import { IncomesRepository } from '@modules/Settings/infra/typeorm/repositories/IncomesRepository';
 
+import type { IShareExpensesPersonRepository } from '@modules/ShareExpensePerson/domain/repositories/IShareExpensesPersonRepository';
+import { ShareExpensesPersonRepository } from '@modules/ShareExpensePerson/infra/typeorm/repositories/ShareExpensesPersonRepository';
+
 container.registerSingleton<IUsersRepository>('UsersRepository', UsersRepository);
 container.registerSingleton<ICardsRepository>('CardsRepository', CardsRepository);
 container.registerSingleton<IExpensesRepository>('ExpensesRepository', ExpensesRepository);
@@ -24,6 +27,7 @@ container.registerSingleton<IExpensesMonthRepository>(
   ExpensesMonthRepository,
 );
 container.registerSingleton<IIncomesRepository>('IncomesRepository', IncomesRepository)
+container.registerSingleton<IShareExpensesPersonRepository>('ShareExpensesPersonRepository', ShareExpensesPersonRepository)
 
 /** Providers register */
 import type { IHashProvider } from '@shared/providers/HashProvider/interfaces/IHashProvider';

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,6 +28,7 @@
 		"react-toastify": "^9.1.1",
 		"styled-components": "^6.1.8",
 		"use-context-selector": "^1.4.1",
+		"use-mask-input": "^3.4.2",
 		"yup": "^1.4.0"
 	},
 	"devDependencies": {

--- a/apps/web/src/components/Box/index.ts
+++ b/apps/web/src/components/Box/index.ts
@@ -1,1 +1,0 @@
-export * from './Box';

--- a/apps/web/src/components/Flex/Flex.ts
+++ b/apps/web/src/components/Flex/Flex.ts
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+
+interface FlexProps {
+	margin?: string;
+	padding?: string;
+	flexDirection?: 'row' | 'column';
+	alignItems?: 'center' | 'flex-start' | 'flex-end' | 'baseline' | 'stretch';
+	justifyContent?: 'center' | 'flex-start' | 'flex-end' | 'space-between' | 'space-around' | 'space-evenly';
+	width?: string;
+	height?: string;
+	gap?: string;
+	flex?: number;
+}
+
+export const Flex = styled.div.withConfig({
+	shouldForwardProp: props =>
+		!['margin', 'padding', 'flexDirection', 'alignItems', 'justifyContent', 'width', 'height', 'gap', 'flex'].includes(
+			props,
+		),
+})<FlexProps>`
+	display: flex;
+	margin: ${({ margin }) => margin};
+	padding: ${({ padding }) => padding};
+	align-items: ${({ alignItems }) => alignItems};
+	justify-content: ${({ justifyContent }) => justifyContent};
+	width: ${({ width }) => width};
+	gap: ${({ gap }) => gap};
+	flex: ${({ flex }) => flex};
+	flex-direction: ${({ flexDirection }) => flexDirection};
+	height: ${({ height }) => height};
+`;

--- a/apps/web/src/components/Flex/index.ts
+++ b/apps/web/src/components/Flex/index.ts
@@ -1,0 +1,1 @@
+export * from './Flex';

--- a/apps/web/src/components/Form/FormGrid/FormGrid.ts
+++ b/apps/web/src/components/Form/FormGrid/FormGrid.ts
@@ -1,12 +1,12 @@
 import styled from 'styled-components';
 
-import { Box } from '@/components/Box';
+import { Flex } from '@/components/Flex';
 
-export const Row = styled(Box)`
+export const Row = styled(Flex)`
 	display: flex;
 `;
 
-export const Column = styled(Box)`
+export const Column = styled(Flex)`
 	display: flex;
 	flex-direction: column;
 `;
@@ -15,7 +15,7 @@ interface GridColumnProps {
 	gridTemplateColumns?: string;
 }
 
-export const GridColumn = styled(Box).withConfig({
+export const GridColumn = styled(Flex).withConfig({
 	shouldForwardProp: prop => !['gridTemplateColumns'].includes(prop),
 })<GridColumnProps>`
 	display: grid;

--- a/apps/web/src/components/Form/Select/Select.tsx
+++ b/apps/web/src/components/Form/Select/Select.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps, ElementRef, forwardRef } from 'react';
+import { ComponentProps, ElementRef, forwardRef, useId } from 'react';
 import ReactSelect, { OptionsOrGroups } from 'react-select';
 
 import { defaultTheme } from '@/styles/theme/default';
@@ -24,9 +24,12 @@ export const Select = forwardRef<ElementRef<typeof ReactSelect>, SelectProps>(fu
 	{ width, ...rest }: SelectProps,
 	ref,
 ) {
+	const id = useId();
+
 	return (
 		<ReactSelect
 			ref={ref}
+			instanceId={id}
 			styles={{
 				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 				// @ts-ignore

--- a/apps/web/src/components/Grid/Grid.ts
+++ b/apps/web/src/components/Grid/Grid.ts
@@ -1,31 +1,39 @@
 import styled from 'styled-components';
 
-interface BoxProps {
+interface GridProps {
 	margin?: string;
 	padding?: string;
-	flexDirection?: 'row' | 'column';
+	gridTemplateColumns?: string;
+	gridTemplateRows?: string;
 	alignItems?: 'center' | 'flex-start' | 'flex-end' | 'baseline' | 'stretch';
 	justifyContent?: 'center' | 'flex-start' | 'flex-end' | 'space-between' | 'space-around' | 'space-evenly';
 	width?: string;
 	height?: string;
 	gap?: string;
-	flex?: number;
 }
 
-export const Box = styled.div.withConfig({
+export const Grid = styled.div.withConfig({
 	shouldForwardProp: props =>
-		!['margin', 'padding', 'flexDirection', 'alignItems', 'justifyContent', 'width', 'height', 'gap', 'flex'].includes(
-			props,
-		),
-})<BoxProps>`
-	display: flex;
+		![
+			'margin',
+			'padding',
+			'gridTemplateColumns',
+			'alignItems',
+			'justifyContent',
+			'width',
+			'height',
+			'gap',
+			'gridTemplateRows',
+		].includes(props),
+})<GridProps>`
+	display: grid;
 	margin: ${({ margin }) => margin};
 	padding: ${({ padding }) => padding};
 	align-items: ${({ alignItems }) => alignItems};
 	justify-content: ${({ justifyContent }) => justifyContent};
 	width: ${({ width }) => width};
-	gap: ${({ gap }) => gap};
-	flex: ${({ flex }) => flex};
-	flex-direction: ${({ flexDirection }) => flexDirection};
 	height: ${({ height }) => height};
+	gap: ${({ gap }) => gap};
+	grid-template-columns: ${({ gridTemplateColumns }) => gridTemplateColumns};
+	grid-template-rows: ${({ gridTemplateRows }) => gridTemplateRows};
 `;

--- a/apps/web/src/components/Grid/index.ts
+++ b/apps/web/src/components/Grid/index.ts
@@ -1,0 +1,1 @@
+export * from './Grid';

--- a/apps/web/src/components/LayoutBox/LayoutBox.styles.ts
+++ b/apps/web/src/components/LayoutBox/LayoutBox.styles.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { Box } from '../Box';
+import { Flex } from '../Flex';
 
 export const LayoutBoxContainer = styled.main`
 	background: ${props => props.theme.colors.white};
@@ -32,25 +32,25 @@ export const LayoutBoxHeaderButtonsContainer = styled.div`
 	gap: 0.5rem;
 `;
 
-export const LayoutBoxContent = styled(Box)`
+export const LayoutBoxContent = styled(Flex)`
 	flex: 1;
 	display: flex;
 	flex-direction: column;
 `;
 
-export const LayoutBoxFooter = styled(Box).attrs({ as: 'footer' })`
+export const LayoutBoxFooter = styled(Flex).attrs({ as: 'footer' })`
 	height: 60px;
 	width: 100%;
 	display: flex;
 	align-items: center;
 `;
 
-export const LayoutBoxFooterLeftSide = styled(Box)`
+export const LayoutBoxFooterLeftSide = styled(Flex)`
 	justify-content: flex-start;
 	width: inherit;
 `;
 
-export const LayoutBoxFooterRightSide = styled(Box)`
+export const LayoutBoxFooterRightSide = styled(Flex)`
 	justify-content: flex-end;
 	width: inherit;
 `;

--- a/apps/web/src/components/index.ts
+++ b/apps/web/src/components/index.ts
@@ -1,5 +1,6 @@
 export * from './BaseModal';
-export * from './Box';
+export * from './Flex';
+export * from './Grid';
 export * from './Button';
 export * from './Header';
 export * from './LayoutBox';

--- a/apps/web/src/constants/inputMasks.ts
+++ b/apps/web/src/constants/inputMasks.ts
@@ -1,0 +1,17 @@
+export enum InputMasks {
+	Cnpj = '99.999.999/9999-99',
+	Cpf = '999.999.999-99',
+	Cep = '99999-999',
+	Tel = '(99) 9999-9999',
+	Phone = '(99) 99999-9999',
+}
+
+export const removeInputMasks = {
+	removeCNPJMask: (value: string) => value.replace(/[^\d]+/g, ''),
+	removeCPFMask: (value: string) => value.replace(/[^\d]+/g, ''),
+	removeCEPMask: (value: string) => value.replace(/[^\d]+/g, ''),
+	removeTELMask: (value: string) => value.replace(/[^\d]+/g, ''),
+	removePHONEMask: (value: string) => value.replace(/[^\d]+/g, ''),
+	removeCurrencyMask: (value: string) => value.replace(/[^\d]+/g, ''),
+	removePercentageMask: (value: string) => value.replace(/[^\d]+/g, ''),
+};

--- a/apps/web/src/constants/navigation.ts
+++ b/apps/web/src/constants/navigation.ts
@@ -40,6 +40,10 @@ export const navigationMapper = {
 				path: 'cards',
 				name: 'Cartões',
 			},
+			{
+				path: 'share-people',
+				name: 'Pessoas',
+			},
 		],
 		visible: false,
 	},

--- a/apps/web/src/constants/yupPtBrTranslations.ts
+++ b/apps/web/src/constants/yupPtBrTranslations.ts
@@ -1,0 +1,40 @@
+import { setLocale } from 'yup';
+
+const translation = {
+	mixed: {
+		default: '${label} é inválido',
+		required: '${label} é um campo obrigatório',
+		oneOf: '${label} deve ser um dos seguintes valores: ${values}',
+		notOneOf: '${label} não pode ser um dos seguintes valores: ${values}',
+	},
+	string: {
+		length: '${label} deve ter exatamente ${length} caracteres',
+		min: '${label} deve ter pelo menos ${min} caracteres',
+		max: '${label} deve ter no máximo ${max} caracteres',
+		email: '${label} tem o formato de e-mail inválido',
+		url: '${label} deve ter um formato de URL válida',
+		trim: '${label} não deve conter espaços no início ou no fim.',
+		lowercase: '${label} deve estar em maiúsculo',
+		uppercase: '${label} deve estar em minúsculo',
+	},
+	number: {
+		min: '${label} deve ser no mínimo ${min}',
+		max: '${label} deve ser no máximo ${max}',
+		lessThan: '${label} deve ser menor que ${less}',
+		moreThan: '${label} deve ser maior que ${more}',
+		notEqual: '${label} não pode ser igual à ${notEqual}',
+		positive: '${label} deve ser um número positivo',
+		negative: '${label} deve ser um número negativo',
+		integer: '${label} deve ser um número inteiro',
+	},
+	date: {
+		min: '${label} deve ser maior que a data ${min}',
+		max: '${label} deve ser menor que a data ${max}',
+	},
+	array: {
+		min: '${label} deve ter no mínimo ${min} itens',
+		max: '${label} deve ter no máximo ${max} itens',
+	},
+};
+
+setLocale(translation);

--- a/apps/web/src/hooks/api/sharePeople/useCreateSharePeople.api.ts
+++ b/apps/web/src/hooks/api/sharePeople/useCreateSharePeople.api.ts
@@ -1,0 +1,27 @@
+import { removeInputMasks } from '@/constants/inputMasks';
+import { SharePeopleFormType } from '@/pages/registrations/share-people/constants/formSchema';
+import { httpClient } from '@/providers/HTTPClient';
+import { useMutation } from 'react-query';
+import { toast } from 'react-toastify';
+
+export type CreateSharePeopleInput = SharePeopleFormType;
+
+export function useCreateSharePeopleApi() {
+	return useMutation({
+		mutationFn: async (formData: CreateSharePeopleInput) => {
+			await httpClient.post('/share-people', {
+				body: {
+					name: formData.name,
+					whatsapp: removeInputMasks.removePHONEMask(formData.whatsapp),
+					day_to_send_message: formData.betterDayTosendInvoice.value,
+				},
+			});
+		},
+		onSuccess: () => {
+			toast.success('Pessoa cadastrada com sucesso!');
+		},
+		onError: () => {
+			toast.error('Não foi possível cadastrar uma nova pessoa. Verifique os dados e tente novamente.');
+		},
+	});
+}

--- a/apps/web/src/pages/_app.page.tsx
+++ b/apps/web/src/pages/_app.page.tsx
@@ -1,4 +1,5 @@
 import 'react-toastify/dist/ReactToastify.css';
+import '@/constants/yupPtBrTranslations';
 import type { AppProps } from 'next/app';
 import { ThemeProvider } from 'styled-components';
 import { ToastContainer } from 'react-toastify';

--- a/apps/web/src/pages/cards/totalizers/CardTotalizer.tsx
+++ b/apps/web/src/pages/cards/totalizers/CardTotalizer.tsx
@@ -5,7 +5,7 @@ import { LayoutBox } from '@/components/LayoutBox';
 import { SEO } from '@/components/SEO';
 import { Table } from '@/components/Table';
 import { Spinner } from '@/components/Spinner';
-import { Box } from '@/components/Box';
+import { Flex } from '@/components/Flex';
 
 import { useCardTotalizer } from './hooks/useCardTotalizer';
 
@@ -28,10 +28,10 @@ export default function CardTotalizerPage() {
 				</LayoutBox.Header>
 				<LayoutBox.Content>
 					{isLoadingTableContent ? (
-						<Box height="200px" flexDirection="column" alignItems="center" justifyContent="center" gap="32px">
+						<Flex height="200px" flexDirection="column" alignItems="center" justifyContent="center" gap="32px">
 							<Spinner />
 							<span>Buscando resumo...</span>
-						</Box>
+						</Flex>
 					) : (
 						<Table columns={cardTotalizerTableColumns} data={cardTotalizerTableData} />
 					)}

--- a/apps/web/src/pages/home/components/ExpensesTable/ExpensesTable.tsx
+++ b/apps/web/src/pages/home/components/ExpensesTable/ExpensesTable.tsx
@@ -9,7 +9,7 @@ import {
 import Link from 'next/link';
 
 import { TextInput } from '@/components/Form/TextInput';
-import { Table, Spinner, Box, Button } from '@/components';
+import { Table, Spinner, Flex, Button } from '@/components';
 import { ExpenseInMonth } from '@/models/ExpenseInMonth';
 import { formatCurrency } from '@/helpers/formatCurrency';
 import { formatParcel } from '@/helpers/formatParcel';
@@ -109,9 +109,9 @@ export default function ExpensesTable({ fetchExpenses, deleteExpense }: Readonly
 
 	if (isFetchingExpenses) {
 		return (
-			<Box alignItems="center" justifyContent="center" width="100%">
+			<Flex alignItems="center" justifyContent="center" width="100%">
 				<Spinner size="md" mode="dark" />
-			</Box>
+			</Flex>
 		);
 	}
 

--- a/apps/web/src/pages/registrations/cards/CreateCardsPage.styles.ts
+++ b/apps/web/src/pages/registrations/cards/CreateCardsPage.styles.ts
@@ -5,7 +5,6 @@ export const RegisterCardsForm = styled.form`
 	display: flex;
 	flex-direction: column;
 	gap: 1rem;
-	padding: 0 2rem 0 2rem;
 `;
 
 export const CreditCardIcon = styled(CreditCard)`

--- a/apps/web/src/pages/registrations/share-people/CreateSharePeople.tsx
+++ b/apps/web/src/pages/registrations/share-people/CreateSharePeople.tsx
@@ -1,7 +1,21 @@
-import { ActionButtons, Button, Flex, Grid, InputLabel, LayoutBox, Select, SEO, TextInput } from '@/components';
-import { betterDaysToSendInvoiceOptions } from './constants/betterDaysToSendInvoiceOptions';
+import { Controller } from 'react-hook-form';
+import { useHookFormMask } from 'use-mask-input';
 
-export default function SharePeople() {
+import { ActionButtons, Flex, Grid, InputLabel, LayoutBox, Select, SEO, TextInput } from '@/components';
+import { betterDaysToSendInvoiceOptions } from './constants/betterDaysToSendInvoiceOptions';
+import { useCreateSharePeople } from './hooks/useCreateSharePeople';
+import { InputMasks } from '@/constants/inputMasks';
+
+export default function SharePeoplePage() {
+	const { formMethods, handleCreateSharePeople } = useCreateSharePeople();
+	const {
+		register,
+		handleSubmit,
+		formState: { errors, isSubmitting },
+		control,
+	} = formMethods;
+	const registerWithMask = useHookFormMask(register);
+
 	return (
 		<>
 			<SEO title="Adicionar nova pessoa" />
@@ -10,19 +24,46 @@ export default function SharePeople() {
 					<LayoutBox.HeaderTitle>Nova pessoa para compartilhar</LayoutBox.HeaderTitle>
 				</LayoutBox.Header>
 				<LayoutBox.Content>
-					<Flex as={'form'} flexDirection="column" gap="1rem">
+					<Flex
+						as={'form'}
+						id="share-people-form-id"
+						flexDirection="column"
+						gap="1rem"
+						onSubmit={handleSubmit(data => handleCreateSharePeople(data))}
+					>
 						<InputLabel>
 							Nome:
-							<TextInput placeholder="Insira o nome da pessoa aqui" />
+							<TextInput
+								placeholder="Insira o nome da pessoa aqui"
+								error={errors.name?.message}
+								{...register('name')}
+							/>
 						</InputLabel>
 						<Grid gap="1.5rem" gridTemplateColumns="minmax(300px, 1fr) minmax(300px, 1fr)">
 							<InputLabel>
 								Whatsapp:
-								<TextInput placeholder="Whatsapp" />
+								<TextInput
+									placeholder="Whatsapp"
+									type="tel"
+									error={errors.whatsapp?.message}
+									{...registerWithMask('whatsapp', [InputMasks.Phone])}
+								/>
 							</InputLabel>
 							<InputLabel>
 								Melhor dia para enviar fatura:
-								<Select placeholder="Selecione o melhor dia" options={betterDaysToSendInvoiceOptions} />
+								<Controller
+									name="betterDayTosendInvoice"
+									control={control}
+									render={({ field }) => {
+										return (
+											<Select
+												placeholder="Selecione o melhor dia"
+												options={betterDaysToSendInvoiceOptions}
+												{...field}
+											/>
+										);
+									}}
+								/>
 							</InputLabel>
 						</Grid>
 					</Flex>
@@ -32,8 +73,8 @@ export default function SharePeople() {
 						<ActionButtons>
 							<ActionButtons.Cancel onClick={() => {}} />
 							<ActionButtons.Submit
-								// isLoading={isCreatingCard}
-								// onClick={handleSubmit(handleCreateCard)}
+								form="share-people-form-id"
+								isLoading={isSubmitting}
 								spinnerConfig={{ mode: 'light', size: 'sm' }}
 							>
 								Criar pessoa

--- a/apps/web/src/pages/registrations/share-people/CreateSharePeople.tsx
+++ b/apps/web/src/pages/registrations/share-people/CreateSharePeople.tsx
@@ -1,0 +1,47 @@
+import { ActionButtons, Button, Flex, Grid, InputLabel, LayoutBox, Select, SEO, TextInput } from '@/components';
+import { betterDaysToSendInvoiceOptions } from './constants/betterDaysToSendInvoiceOptions';
+
+export default function SharePeople() {
+	return (
+		<>
+			<SEO title="Adicionar nova pessoa" />
+			<LayoutBox>
+				<LayoutBox.Header>
+					<LayoutBox.HeaderTitle>Nova pessoa para compartilhar</LayoutBox.HeaderTitle>
+				</LayoutBox.Header>
+				<LayoutBox.Content>
+					<Flex as={'form'} flexDirection="column" gap="1rem">
+						<InputLabel>
+							Nome:
+							<TextInput placeholder="Insira o nome da pessoa aqui" />
+						</InputLabel>
+						<Grid gap="1.5rem" gridTemplateColumns="minmax(300px, 1fr) minmax(300px, 1fr)">
+							<InputLabel>
+								Whatsapp:
+								<TextInput placeholder="Whatsapp" />
+							</InputLabel>
+							<InputLabel>
+								Melhor dia para enviar fatura:
+								<Select placeholder="Selecione o melhor dia" options={betterDaysToSendInvoiceOptions} />
+							</InputLabel>
+						</Grid>
+					</Flex>
+				</LayoutBox.Content>
+				<LayoutBox.Footer>
+					<LayoutBox.FooterRightSide>
+						<ActionButtons>
+							<ActionButtons.Cancel onClick={() => {}} />
+							<ActionButtons.Submit
+								// isLoading={isCreatingCard}
+								// onClick={handleSubmit(handleCreateCard)}
+								spinnerConfig={{ mode: 'light', size: 'sm' }}
+							>
+								Criar pessoa
+							</ActionButtons.Submit>
+						</ActionButtons>
+					</LayoutBox.FooterRightSide>
+				</LayoutBox.Footer>
+			</LayoutBox>
+		</>
+	);
+}

--- a/apps/web/src/pages/registrations/share-people/constants/betterDaysToSendInvoiceOptions.ts
+++ b/apps/web/src/pages/registrations/share-people/constants/betterDaysToSendInvoiceOptions.ts
@@ -1,0 +1,14 @@
+export const betterDaysToSendInvoiceOptions = [
+	{
+		label: 'Dia 01',
+		value: '1',
+	},
+	{
+		label: 'Dia 05',
+		value: '5',
+	},
+	{
+		label: 'Dia 10',
+		value: '10',
+	},
+];

--- a/apps/web/src/pages/registrations/share-people/constants/formSchema.ts
+++ b/apps/web/src/pages/registrations/share-people/constants/formSchema.ts
@@ -1,0 +1,16 @@
+import * as yup from 'yup';
+
+export const sharePeopleFormSchema = yup.object().shape({
+	name: yup.string().label('Nome').required(),
+	whatsapp: yup.string().label('Whatsapp').required(),
+	betterDayTosendInvoice: yup
+		.object()
+		.label('Dia para enviar o fatura')
+		.shape({
+			label: yup.string().required(),
+			value: yup.string().required(),
+		})
+		.required(),
+});
+
+export type SharePeopleFormType = yup.InferType<typeof sharePeopleFormSchema>;

--- a/apps/web/src/pages/registrations/share-people/hooks/useCreateSharePeople.ts
+++ b/apps/web/src/pages/registrations/share-people/hooks/useCreateSharePeople.ts
@@ -1,0 +1,22 @@
+import { yupResolver } from '@hookform/resolvers/yup';
+import { useForm } from 'react-hook-form';
+import { sharePeopleFormSchema, SharePeopleFormType } from '../constants/formSchema';
+import { betterDaysToSendInvoiceOptions } from '../constants/betterDaysToSendInvoiceOptions';
+import { useCreateSharePeopleApi } from '@/hooks/api/sharePeople/useCreateSharePeople.api';
+
+export function useCreateSharePeople() {
+	const { mutateAsync: handleCreateSharePeople } = useCreateSharePeopleApi();
+
+	const formMethods = useForm<SharePeopleFormType>({
+		resolver: yupResolver(sharePeopleFormSchema),
+		defaultValues: {
+			betterDayTosendInvoice: betterDaysToSendInvoiceOptions[1],
+		},
+	});
+	console.log(formMethods.formState.errors);
+
+	return {
+		formMethods,
+		handleCreateSharePeople,
+	};
+}

--- a/apps/web/src/pages/registrations/share-people/index.page.tsx
+++ b/apps/web/src/pages/registrations/share-people/index.page.tsx
@@ -1,0 +1,1 @@
+export { default } from './CreateSharePeople';

--- a/package-lock.json
+++ b/package-lock.json
@@ -5111,6 +5111,7 @@
         "react-toastify": "^9.1.1",
         "styled-components": "^6.1.8",
         "use-context-selector": "^1.4.1",
+        "use-mask-input": "^3.4.2",
         "yup": "^1.4.0"
       },
       "devDependencies": {
@@ -10671,6 +10672,19 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-mask-input": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/use-mask-input/-/use-mask-input-3.4.2.tgz",
+      "integrity": "sha512-d+lYFl/6rsmdya3bZfMoMqZYC5uSKDPtWp/BD+FQ6KRsAKaPfRO1Z/jvagrytKCpvIrpER3i/WKC/4baIzlr+A==",
+      "engines": {
+        "node": ">=16",
+        "npm": ">=7"
+      },
+      "peerDependencies": {
+        "react": ">=16.4 || 17 || 18 || 20",
+        "react-dom": ">=16.4 || 17 || 18 || 20"
       }
     },
     "node_modules/use-sidecar": {

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "test": "turbo run test",
     "dev": "turbo run dev --parallel",
     "migration:run": "turbo run migration:run --parallel",
-    "container:db": "docker-compose up -d datasource",
-    "container:up": "docker-compose up -d datasource api web",
-    "container:down": "docker-compose stop"
+    "container:db": "docker compose up -d datasource",
+    "container:up": "docker compose up -d datasource api web",
+    "container:down": "docker compose stop"
   }
 }


### PR DESCRIPTION
## Contém nesse PR ✍🏻 
- **[api]** Foi implementado o cadastro de pessoas divisoras
- **[api]** Foi adicionado a migration de criacão da tabela share_expense_people
- **[api]** Foi adiciona testes unitários para modelo e service de criacão
- **[web]** Adicionado tela de cadastro de pessoas divisoras
- **[web]** Adicionado tradução das mensagens de erro do validador _yup_.

## Resultado  🎉
![image](https://github.com/user-attachments/assets/4ebfb957-10e6-42f6-a83b-87b722a8c8bd)

## Testes 🧪 
![image](https://github.com/user-attachments/assets/865492e9-7b6b-464c-9bd1-f2ab52e51af8)