### PR TITLE
[api] dt/FA-27 - Ajustes na ordenação da listagem de despesas no mês

### DIFF
--- a/apps/api/src/modules/Expense/infra/typeorm/repositories/ExpensesMonthRepository.ts
+++ b/apps/api/src/modules/Expense/infra/typeorm/repositories/ExpensesMonthRepository.ts
@@ -40,6 +40,12 @@ export class ExpensesMonthRepository implements IExpensesMonthRepository {
         }),
       },
       relations: ['expense', 'expense.card'],
+      order: {
+        expense: {
+          is_recurring: 'DESC',
+          created_at: 'ASC'
+        }
+      }
     });
 
     return expensesInMonth;


### PR DESCRIPTION
### Contém nesse PR:
- Ordenação da listagem para sempre mostrar no topo despesas recorrentes e ordenadas pelo created_at